### PR TITLE
change download link from http:// to https://

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
 						<h1>SelfControl</h1>
 						<h2 class="tagline">A free Mac application to help you avoid distracting websites.</h2>
 						<p class="download-info">
-							<a href="http://downloads.selfcontrolapp.com/SelfControl-3.0.3.zip" class="btn btn-primary btn-large jumbo-button" onclick="_gaq.push(['_trackEvent', 'Hero button actions', 'Download', 'Download SelfControl']);">
+							<a href="https://downloads.selfcontrolapp.com/SelfControl-3.0.3.zip" class="btn btn-primary btn-large jumbo-button" onclick="_gaq.push(['_trackEvent', 'Hero button actions', 'Download', 'Download SelfControl']);">
 								Download SelfControl
 								<br>
 								<small>v3.0.3 for Mac OS X 10.8+</small>


### PR DESCRIPTION
Chrome blocks the download if the link starts with http://

"SelfControl-3.0.3.zip can't be downloaded securely"

https://i.imgur.com/TlxE5to.png